### PR TITLE
AdHoc (dependency) Pip should only be used once

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -3,7 +3,7 @@ galaxy_info:
   description: Sitewards' DB import from AWS S3 bucket, for use on testing systems
   company: Sitewards
   license: OSL-3.0
-  min_ansible_version: 2.4
+  min_ansible_version: 2.8
   galaxy_tags: []
 
 dependencies: []

--- a/tasks/dependencies/aws-s3.yml
+++ b/tasks/dependencies/aws-s3.yml
@@ -1,9 +1,7 @@
 ---
 - name: "Install the required python packages for AWS"
   pip:
-    name: "{{ item }}"
+    name: ['boto3']
     state: "latest"
   become: "True"
   become_user: "root"
-  with_items:
-    - "boto3"


### PR DESCRIPTION
After upgrading to ansible 2.8 we get the following deprecation warning:

[DEPRECATION WARNING]: Invoking "pip" only once while using a loop via
squash_actions is deprecated. Instead of using a loop to supply multiple items
and specifying `name: "{{ item }}"`, please use `name: ['boto3']` and remove
the loop. This feature will be removed in version 2.11. Deprecation warnings
can be disabled by setting deprecation_warnings=False in ansible.cfg.

This commit should fix the deprication warning.