### PR TITLE
ADHOC feat async-import: make things faster through parallel run

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -45,3 +45,13 @@ import_db_post_import_sql_queries: []
 
 ## Tmp path to put downloaded files while preparing them for import
 import_db_tmp_path: "/tmp/import_db"
+
+## Allow async execution
+## in case activated one *must* add a task like that to playbook
+## - name: 'Import DB - check on async task'
+#      async_status:
+#        jid: "{{ import_db_sleeper.ansible_job_id }}"
+#      register: job_result
+#      until: job_result.finished
+#      retries: 30
+import_db_allow_async: false

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -1,0 +1,9 @@
+---
+- name: "Clean up tmp db files"
+  file:
+    path: "{{ item }}"
+    state: "absent"
+  with_items:
+    - "{{ import_db_tmp_path }}/db_dump.sql"
+    - "{{ import_db_tmp_path }}/db_dump.sql.gz"
+    - "{{ import_db_tmp_path }}"

--- a/tasks/import.yml
+++ b/tasks/import.yml
@@ -25,19 +25,25 @@
     login_user: "root"
   when: "import_db_downloaded_archive.changed"
 
-- name: "Restore the database"
+- name: "Restore the database asyncronously"
   mysql_db:
     name: "{{ import_db_database_name }}"
     state: "import"
     target: "{{ import_db_tmp_path }}/db_dump.sql"
     login_password: "{{ import_db_root_password }}"
     login_user: "root"
+  async: 600
+  poll: 0
+  notify: "Clean up tmp db files"
+  register: import_db_sleeper
+  when: import_db_allow_async
 
-- name: "Clean up the db from /tmp"
-  file:
-    path: "{{ item }}"
-    state: "absent"
-  with_items:
-    - "{{ import_db_tmp_path }}/db_dump.sql"
-    - "{{ import_db_tmp_path }}/db_dump.sql.gz"
-    - "{{ import_db_tmp_path }}"
+- name: "Restore the database syncronously"
+  mysql_db:
+    name: "{{ import_db_database_name }}"
+    state: "import"
+    target: "{{ import_db_tmp_path }}/db_dump.sql"
+    login_password: "{{ import_db_root_password }}"
+    login_user: "root"
+  notify: "Clean up tmp db files"
+  when: not import_db_allow_async


### PR DESCRIPTION
if database is imported asyncronously - playbook can proceed with other
tasks, and then we can sync again right before finish of playbook or in
other specific place.

see:
* https://www.treitos.com/blog/2020/improving-ansible-performance.html
* https://docs.ansible.com/ansible/2.9/user_guide/playbooks_async.html
* https://docs.ansible.com/ansible/latest/user_guide/playbooks_handlers.html