### PR TITLE
ADHOC fix async-import: allow control over timeout

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -56,6 +56,10 @@ import_db_tmp_path: "/tmp/import_db"
 #      retries: 30
 import_db_allow_async: false
 
+## Async operation timeout, in seconds
+## set to a higher value if you have a bigger database dump
+import_db_async_timeout: 600
+
 ## This is the list of required dependencies for Azure
 ## do not override this variable unless you know what you are doing,
 ## package dependencies should only be overridden in edge cases or to enforce a specific version

--- a/tasks/import.yml
+++ b/tasks/import.yml
@@ -25,20 +25,20 @@
     login_user: "root"
   when: "import_db_downloaded_archive.changed"
 
-- name: "Restore the database asyncronously"
+- name: "Restore the database asynchronously"
   mysql_db:
     name: "{{ import_db_database_name }}"
     state: "import"
     target: "{{ import_db_tmp_path }}/db_dump.sql"
     login_password: "{{ import_db_root_password }}"
     login_user: "root"
-  async: 600
+  async: import_db_async_timeout
   poll: 0
   notify: "Clean up tmp db files"
   register: import_db_sleeper
   when: import_db_allow_async
 
-- name: "Restore the database syncronously"
+- name: "Restore the database synchronously"
   mysql_db:
     name: "{{ import_db_database_name }}"
     state: "import"


### PR DESCRIPTION
on bigger databases it might take longer than 10 minutes,
role users would want to control the timeout in this case